### PR TITLE
feat(campaign): tùy chỉnh chữ hiển thị mention tag-all

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -102,7 +102,6 @@ jobs:
         if: needs.resolve-tag.outputs.should_publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          repository: babyvibe/deplao-builder
           tag_name: ${{ needs.resolve-tag.outputs.tag }}
           name: "Deplao ${{ needs.resolve-tag.outputs.tag }}"
           files: |
@@ -152,7 +151,6 @@ jobs:
         if: needs.resolve-tag.outputs.should_publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          repository: babyvibe/deplao-builder
           tag_name: ${{ needs.resolve-tag.outputs.tag }}
           name: "Deplao ${{ needs.resolve-tag.outputs.tag }}"
           files: |
@@ -219,7 +217,6 @@ jobs:
         if: needs.resolve-tag.outputs.should_publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          repository: babyvibe/deplao-builder
           tag_name: ${{ needs.resolve-tag.outputs.tag }}
           name: "Deplao ${{ needs.resolve-tag.outputs.tag }}"
           files: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -118,14 +118,13 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          repository: babyvibe/deplao-builder
           tag_name: ${{ steps.get_tag.outputs.tag }}
           name: "Deplao ${{ steps.get_tag.outputs.tag }}"
           files: |
             dist-electron-build/*.dmg
             dist-electron-build/*.blockmap
             dist-electron-build/latest-mac.yml
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           prerelease: false
           make_latest: true

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -70,6 +70,8 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: 🏗️ Build E2EE bridge (Go)
+        # E2EE là tùy chọn — app chạy được không cần bridge (giống predev script bỏ qua khi fail)
+        continue-on-error: true
         run: npm run build:bridge-e2ee
 
       - name: 🏗️ Compile TypeScript (electron)
@@ -103,7 +105,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          repository: babyvibe/deplao-builder
           tag_name: ${{ steps.get_tag.outputs.tag }}
           name: "Deplao ${{ steps.get_tag.outputs.tag }}"
           files: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -85,14 +85,13 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          repository: babyvibe/deplao-builder
           tag_name: ${{ steps.get_tag.outputs.tag }}
           name: "Deplao ${{ steps.get_tag.outputs.tag }}"
           files: |
             dist-electron-build/*.exe
             dist-electron-build/*.blockmap
             dist-electron-build/latest.yml
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           prerelease: false
           make_latest: false

--- a/electron/ipc/relayIpc.ts
+++ b/electron/ipc/relayIpc.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron';
 import HttpRelayService from '../../src/services/http/HttpRelayService';
+import DatabaseService from '../../src/services/database/DatabaseService';
 import Logger from '../../src/utils/Logger';
 import os from 'os';
 
@@ -84,5 +85,32 @@ export function registerRelayIpc(): void {
         }
     });
 
-    Logger.log('[relayIpc] Registered 7 relay IPC channels');
+    // ─── Tunnel provider config (cloudflare | ngrok static domain) ──────────────
+    ipcMain.handle('relay:getTunnelConfig', async () => {
+        try {
+            const db = DatabaseService.getInstance();
+            return {
+                success: true,
+                provider: db.getSetting('relay_tunnel_provider') || 'cloudflare',
+                authtoken: db.getSetting('relay_ngrok_authtoken') || '',
+                domain: db.getSetting('relay_ngrok_domain') || '',
+            };
+        } catch (err: any) {
+            return { success: false, error: err.message };
+        }
+    });
+
+    ipcMain.handle('relay:setTunnelConfig', async (_e, cfg: { provider?: string; authtoken?: string; domain?: string } = {}) => {
+        try {
+            const db = DatabaseService.getInstance();
+            if (cfg.provider !== undefined) db.setSetting('relay_tunnel_provider', cfg.provider);
+            if (cfg.authtoken !== undefined) db.setSetting('relay_ngrok_authtoken', cfg.authtoken);
+            if (cfg.domain !== undefined) db.setSetting('relay_ngrok_domain', cfg.domain);
+            return { success: true };
+        } catch (err: any) {
+            return { success: false, error: err.message };
+        }
+    });
+
+    Logger.log('[relayIpc] Registered 9 relay IPC channels');
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -35,6 +35,7 @@ import CRMQueueService from '../src/services/crm/CRMQueueService';
 import FileStorageService from '../src/services/file/FileStorageService';
 import TrackingService from '../src/services/tracking/TrackingService';
 import { SHOW_DEV_TOOLS, IS_DEV_BUILD } from '../src/configs/BuildConfig';
+import Logger from '../src/utils/Logger';
 
 const isDev = IS_DEV_BUILD;
 let isQuitting = false;
@@ -438,6 +439,16 @@ function registerWindowControls() {
   });
 
   ipcMain.handle('window:isMaximized', () => mainWindow?.isMaximized() ?? false);
+
+  // ─── Nhật ký (Logger) → renderer ─────────────────────────────────
+  // Hook console toàn cục để cả console.* thẳng (không qua Logger) cũng vào buffer
+  Logger.installConsoleHook();
+  // Forward mỗi log mới sang tab Nhật ký (throttle-free, buffer đã giới hạn 2000 dòng)
+  Logger.onEntry((entry) => {
+    try { mainWindow?.webContents.send('log:entry', entry); } catch { /* window đã đóng */ }
+  });
+  ipcMain.handle('log:getBuffer', () => Logger.getBuffer());
+  ipcMain.handle('log:clear', () => { Logger.clearBuffer(); return true; });
 
   // Open external link in browser
   ipcMain.on('shell:openExternal', (_event, url: string) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -329,6 +329,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     install:  () => ipcRenderer.send('update:install'),
   },
 
+  // ─── Nhật ký (Logger) ─────────────────────────────────────────────
+  logs: {
+    getBuffer: () => ipcRenderer.invoke('log:getBuffer'),
+    clear:     () => ipcRenderer.invoke('log:clear'),
+  },
+
   // ─── Integration Hub ──────────────────────────────────────────────
   integration: {
     list:            () => ipcRenderer.invoke('integration:list'),
@@ -432,6 +438,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     startTunnel:         () => ipcRenderer.invoke('relay:startTunnel'),
     stopTunnel:          () => ipcRenderer.invoke('relay:stopTunnel'),
     getTunnelStatus:     () => ipcRenderer.invoke('relay:getTunnelStatus'),
+    getTunnelConfig:     () => ipcRenderer.invoke('relay:getTunnelConfig'),
+    setTunnelConfig:     (cfg: { provider?: string; authtoken?: string; domain?: string }) => ipcRenderer.invoke('relay:setTunnelConfig', cfg),
   },
 
   // ─── Facebook ─────────────────────────────────────────────────────
@@ -627,6 +635,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       'app:openThread',
       'app:windowFocus',
       'app:drawBadge',
+      'log:entry',
       'crm:queueUpdate',
       'crm:queueStatus',
       'crm:campaignDone',

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "otplib": "^13.4.0",
         "proxy-agent": "^8.0.1",
         "quill": "^2.0.3",
+        "react-is": "^18.3.1",
         "react-quill-new": "^3.8.3",
         "react-zoom-pan-pinch": "^3.7.0",
         "reactflow": "^11.11.4",
@@ -12209,13 +12210,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/proc-log": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
@@ -12534,6 +12528,12 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react-quill-new": {
       "version": "3.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "Deplao",
-  "version": "26.7.1",
+  "version": "26.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Deplao",
-      "version": "26.7.1",
+      "version": "26.7.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@ngrok/ngrok": "^1.7.0",
         "axios": "^1.7.8",
         "axios-cookiejar-support": "^5.0.3",
         "bcryptjs": "^3.0.3",
@@ -1050,72 +1051,6 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@electron/windows-sign": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cross-dirname": "^0.1.0",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.1.1",
-        "minimist": "^1.2.8",
-        "postject": "^1.0.0-alpha.6"
-      },
-      "bin": {
-        "electron-windows-sign": "bin/electron-windows-sign.js"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2749,6 +2684,247 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@ngrok/ngrok": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok/-/ngrok-1.7.0.tgz",
+      "integrity": "sha512-P06o9TpxrJbiRbHQkiwy/rUrlXRupc+Z8KT4MiJfmcdWxvIdzjCaJOdnNkcOTs6DMyzIOefG5tvk/HLdtjqr0g==",
+      "license": "(MIT OR Apache-2.0)",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@ngrok/ngrok-android-arm64": "1.7.0",
+        "@ngrok/ngrok-darwin-arm64": "1.7.0",
+        "@ngrok/ngrok-darwin-universal": "1.7.0",
+        "@ngrok/ngrok-darwin-x64": "1.7.0",
+        "@ngrok/ngrok-freebsd-x64": "1.7.0",
+        "@ngrok/ngrok-linux-arm-gnueabihf": "1.7.0",
+        "@ngrok/ngrok-linux-arm64-gnu": "1.7.0",
+        "@ngrok/ngrok-linux-arm64-musl": "1.7.0",
+        "@ngrok/ngrok-linux-x64-gnu": "1.7.0",
+        "@ngrok/ngrok-linux-x64-musl": "1.7.0",
+        "@ngrok/ngrok-win32-arm64-msvc": "1.7.0",
+        "@ngrok/ngrok-win32-ia32-msvc": "1.7.0",
+        "@ngrok/ngrok-win32-x64-msvc": "1.7.0"
+      }
+    },
+    "node_modules/@ngrok/ngrok-android-arm64": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-android-arm64/-/ngrok-android-arm64-1.7.0.tgz",
+      "integrity": "sha512-8tco3ID6noSaNy+CMS7ewqPoIkIM6XO5COCzsUp3Wv3XEbMSyn65RN6cflX2JdqLfUCHcMyD0ahr9IEiHwqmbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-arm64": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-arm64/-/ngrok-darwin-arm64-1.7.0.tgz",
+      "integrity": "sha512-+dmJSOzSO+MNDVrPOca2yYDP1W3KfP4qOlAkarIeFRIfqonQwq3QCBmcR7HAlZocLsSqEwyG6KP4RRvAuT0WGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-universal": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-universal/-/ngrok-darwin-universal-1.7.0.tgz",
+      "integrity": "sha512-fDEfewyE2pWGFBhOSwQZObeHUkc65U1l+3HIgSOe094TMHsqmyJD0KTCgW9KSn0VP4OvDZbAISi1T3nvqgZYhQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-x64": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-x64/-/ngrok-darwin-x64-1.7.0.tgz",
+      "integrity": "sha512-+fwMi5uHd9G8BS42MMa9ye6exI5lwTcjUO6Ut497Vu0qgLONdVRenRqnEePV+Q3KtQR7NjqkMnomVfkr9MBjtw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-freebsd-x64": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-freebsd-x64/-/ngrok-freebsd-x64-1.7.0.tgz",
+      "integrity": "sha512-2OGgbrjy3yLRrqAz5N6hlUKIWIXSpR5RjQa2chtZMsSbszQ6c9dI+uVQfOKAeo05tHMUgrYAZ7FocC+ig0dzdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm-gnueabihf": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm-gnueabihf/-/ngrok-linux-arm-gnueabihf-1.7.0.tgz",
+      "integrity": "sha512-SN9YIfEQiR9xN90QVNvdgvAemqMLoFVSeTWZs779145hQMhvF9Qd9rnWi6J+2uNNK10OczdV1oc/nq1es7u/3g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm64-gnu": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-gnu/-/ngrok-linux-arm64-gnu-1.7.0.tgz",
+      "integrity": "sha512-KDMgzPKFU2kbpVSaA2RZBBia5IPdJEe063YlyVFnSMJmPYWCUnMwdybBsucXfV9u1Lw/ZjKTKotIlbTWGn3HGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm64-musl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-musl/-/ngrok-linux-arm64-musl-1.7.0.tgz",
+      "integrity": "sha512-e66vUdVrBlQ0lT9ZdamB4U604zt5Gualt8/WVcUGzbu8s5LajWd6g/mzZCUjK4UepjvMpfgmCp1/+rX7Rk8d5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-x64-gnu": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-gnu/-/ngrok-linux-x64-gnu-1.7.0.tgz",
+      "integrity": "sha512-M6gF0DyOEFqXLfWxObfL3bxYZ4+PnKBHuyLVaqNfFN9Y5utY2mdPOn5422Ppbk4XoIK5/YkuhRqPJl/9FivKEw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-x64-musl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-musl/-/ngrok-linux-x64-musl-1.7.0.tgz",
+      "integrity": "sha512-4Ijm0dKeoyzZTMaYxR2EiNjtlK81ebflg/WYIO1XtleFrVy4UJEGnxtxEidYoT4BfCqi4uvXiK2Mx216xXKvog==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-arm64-msvc": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-arm64-msvc/-/ngrok-win32-arm64-msvc-1.7.0.tgz",
+      "integrity": "sha512-u7qyWIJI2/YG1HTBnHwUR1+Z2tyGfAsUAItJK/+N1G0FeWJhIWQvSIFJHlaPy4oW1Dc8mSDBX9qvVsiQgLaRFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-ia32-msvc": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-ia32-msvc/-/ngrok-win32-ia32-msvc-1.7.0.tgz",
+      "integrity": "sha512-/UdYUsLNv/Q8j9YJsyIfq/jLCoD8WP+NidouucTUzSoDtmOsXBBT3itLrmPiZTEdEgKiFYLuC1Zon8XQQvbVLA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-x64-msvc": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-x64-msvc/-/ngrok-win32-x64-msvc-1.7.0.tgz",
+      "integrity": "sha512-UFJg/duEWzZlLkEs61Gz6/5nYhGaKI62I8dvUGdBR3NCtIMagehnFaFxmnXZldyHmCM8U0aCIFNpWRaKcrQkoA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
@@ -4198,14 +4374,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -6170,15 +6346,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cross-dirname": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -6294,7 +6461,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -6993,19 +7160,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
-      "integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "app-builder-lib": "26.8.1",
-        "builder-util": "26.8.1",
-        "electron-winstaller": "5.4.0"
-      }
-    },
     "node_modules/electron-builder/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -7180,44 +7334,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/electron-winstaller": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
-      "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@electron/asar": "^3.2.1",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
-        "lodash": "^4.17.21",
-        "temp": "^0.9.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@electron/windows-sign": "^1.1.2"
-      }
-    },
-    "node_modules/electron-winstaller/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/electron/node_modules/@types/node": {
@@ -10171,6 +10287,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -10583,6 +10700,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -10835,20 +10953,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -12017,36 +12121,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/postject": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "commander": "^9.4.0"
-      },
-      "bin": {
-        "postject": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/postject/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -12438,6 +12512,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -12450,6 +12525,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -12458,13 +12534,6 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
-    },
-    "node_modules/react-is": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-quill-new": {
       "version": "3.8.3",
@@ -12826,21 +12895,6 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
-    "node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/roarr": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -13007,6 +13061,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -13885,21 +13940,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/temp": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
-      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mkdirp": "^0.5.1",
-        "rimraf": "~2.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/temp-file": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
@@ -14461,7 +14501,7 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
       "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Deplao",
-  "version": "26.7.1",
+  "version": "26.7.2",
   "description": "Phần mềm desktop quản lý Zalo & Facebook cá nhân Đa tài khoản tích hợp CRM, ERP, POS, Workflow và AI Assistant giúp đội nhóm bán hàng, chăm sóc khách hàng và marketing trên Zalo vận hành tập trung trong một ứng dụng duy nhất.",
   "main": "dist-electron/electron/main.js",
   "scripts": {
@@ -17,6 +17,7 @@
   "homepage": "https://deplaoapp.com",
   "license": "MIT",
   "dependencies": {
+    "@ngrok/ngrok": "^1.7.0",
     "axios": "^1.7.8",
     "axios-cookiejar-support": "^5.0.3",
     "bcryptjs": "^3.0.3",
@@ -113,12 +114,14 @@
       "resources/**/*",
       "node_modules/ffmpeg-static/**/*",
       "node_modules/cloudflared/**/*",
+      "node_modules/@ngrok/ngrok/**/*",
       "package.json"
     ],
     "asarUnpack": [
       "resources/icons/**",
       "node_modules/better-sqlite3/**",
       "node_modules/cloudflared/**",
+      "node_modules/@ngrok/ngrok/**",
       "node_modules/ffmpeg-static/**"
     ],
     "afterPack": "./scripts/after-pack.js",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "otplib": "^13.4.0",
     "proxy-agent": "^8.0.1",
     "quill": "^2.0.3",
+    "react-is": "^18.3.1",
     "react-quill-new": "^3.8.3",
     "react-zoom-pan-pinch": "^3.7.0",
     "reactflow": "^11.11.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Deplao",
-  "version": "26.7.3",
+  "version": "26.7.4",
   "description": "Phần mềm desktop quản lý Zalo & Facebook cá nhân Đa tài khoản tích hợp CRM, ERP, POS, Workflow và AI Assistant giúp đội nhóm bán hàng, chăm sóc khách hàng và marketing trên Zalo vận hành tập trung trong một ứng dụng duy nhất.",
   "main": "dist-electron/electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Deplao",
-  "version": "26.7.2",
+  "version": "26.7.3",
   "description": "Phần mềm desktop quản lý Zalo & Facebook cá nhân Đa tài khoản tích hợp CRM, ERP, POS, Workflow và AI Assistant giúp đội nhóm bán hàng, chăm sóc khách hàng và marketing trên Zalo vận hành tập trung trong một ứng dụng duy nhất.",
   "main": "dist-electron/electron/main.js",
   "scripts": {

--- a/src/__tests__/message-markup.test.ts
+++ b/src/__tests__/message-markup.test.ts
@@ -1,0 +1,55 @@
+import { parseMarkup } from '../services/crm/message-markup';
+
+describe('parseMarkup', () => {
+  it('text trơn → không style', () => {
+    expect(parseMarkup('Xin chào')).toEqual({ text: 'Xin chào', styles: [] });
+  });
+
+  it('in đậm cơ bản: offset trên text sạch', () => {
+    const r = parseMarkup('a[b]bc[/b]d');
+    expect(r.text).toBe('abcd');
+    expect(r.styles).toEqual([{ start: 1, len: 2, st: 'b' }]);
+  });
+
+  it('màu đỏ → mã zca-js', () => {
+    const r = parseMarkup('[red]HOT[/red]');
+    expect(r.text).toBe('HOT');
+    expect(r.styles).toEqual([{ start: 0, len: 3, st: 'c_db342e' }]);
+  });
+
+  it('thẻ lồng nhau → nhiều style cùng range', () => {
+    const r = parseMarkup('[b][red]X[/red][/b]');
+    expect(r.text).toBe('X');
+    expect(r.styles).toEqual(
+      expect.arrayContaining([
+        { start: 0, len: 1, st: 'c_db342e' },
+        { start: 0, len: 1, st: 'b' },
+      ]),
+    );
+    expect(r.styles).toHaveLength(2);
+  });
+
+  it('thẻ lạ giữ nguyên như text thường', () => {
+    const r = parseMarkup('gia [x]100[/x]k');
+    expect(r.text).toBe('gia [x]100[/x]k');
+    expect(r.styles).toEqual([]);
+  });
+
+  it('thẻ đóng không mở → bỏ qua, không crash', () => {
+    const r = parseMarkup('abc[/b]d');
+    expect(r.text).toBe('abcd');
+    expect(r.styles).toEqual([]);
+  });
+
+  // Cạm bẫy chính: {name} thay lúc gửi → offset phải luôn khớp text thật.
+  it('offset đúng sau khi {name} đã substitute (tên dài/ngắn khác nhau)', () => {
+    const tpl = 'Chào [b]{name}[/b] nhé';
+    const short = parseMarkup(tpl.replace('{name}', 'An'));
+    expect(short.text).toBe('Chào An nhé');
+    expect(short.styles).toEqual([{ start: 5, len: 2, st: 'b' }]);
+
+    const long = parseMarkup(tpl.replace('{name}', 'Nguyễn Văn Bình'));
+    expect(long.text).toBe('Chào Nguyễn Văn Bình nhé');
+    expect(long.styles).toEqual([{ start: 5, len: 15, st: 'b' }]);
+  });
+});

--- a/src/plans/260710-1432-per-account-reply-send-queue/phase-01-account-send-queue-module.md
+++ b/src/plans/260710-1432-per-account-reply-send-queue/phase-01-account-send-queue-module.md
@@ -1,0 +1,44 @@
+# Phase 01 — Module AccountSendQueue
+
+## Mục tiêu
+Một class quản lý hàng đợi gửi tin tuần tự theo `zaloId`. Không phụ thuộc gì vào Zalo API —
+nhận vào 1 hàm `task: () => Promise<T>`, đảm bảo các task **cùng account** chạy nối đuôi, giữa
+2 task chờ delay ngẫu nhiên.
+
+## Thiết kế (KISS — promise-chain, không cần setInterval)
+```
+enqueue(zaloId, task, minMs, maxMs):
+  chain = tails.get(zaloId) ?? Promise.resolve()
+  next = chain
+    .then(() => task())              // chạy task hiện tại
+    .finally(() => waitRandom(min,max))  // xong thì chờ delay TRƯỚC khi nhả cho task kế
+  tails.set(zaloId, next.catch(()=>{})) // lỗi 1 task không đứt cả hàng
+  return next                         // trả promise của task để caller await kết quả
+```
+
+Vì sao promise-chain thay vì token-bucket như CRMQueueService?
+- Auto-reply là **on-demand**, không cần dispatcher loop chạy nền tốn CPU.
+- CRMQueue phải dò DB pending → hợp với setInterval. Ở đây task đã nằm sẵn trong RAM.
+- Ít code hơn, không cần cleanup timer.
+
+## Chi tiết
+- `tails: Map<string, Promise<any>>` — đuôi hàng đợi mỗi account.
+- delay chỉ áp **giữa** các task (sau task xong, trước task kế). Task đầu tiên của account rảnh → chạy ngay.
+- `min<=0 && max<=0` → không delay (backward compatible, giữ hành vi cũ).
+- Chống rò rỉ: sau khi 1 task hoàn tất và nếu nó vẫn là đuôi hiện tại → xóa entry khỏi Map.
+
+## File
+- TẠO `src/services/workflow/AccountSendQueue.ts` (~70 dòng)
+- Export singleton `AccountSendQueue.getInstance()` giống pattern các service khác.
+
+## Self-check (ponytail: 1 test runnable)
+- TẠO `src/services/workflow/__tests__/AccountSendQueue.test.ts`
+- Test 1: 3 task cùng account chạy tuần tự (thứ tự hoàn tất = thứ tự enqueue).
+- Test 2: task cùng account cách nhau >= minMs (đo timestamp).
+- Test 3: 2 account khác nhau chạy song song (task account B không phải chờ account A xong hết).
+- Test 4: 1 task throw không làm đứng hàng đợi (task kế vẫn chạy).
+
+## Todo
+- [ ] Viết AccountSendQueue.ts
+- [ ] Viết test
+- [ ] Chạy test pass

--- a/src/plans/260710-1432-per-account-reply-send-queue/phase-02-integrate-workflow-engine.md
+++ b/src/plans/260710-1432-per-account-reply-send-queue/phase-02-integrate-workflow-engine.md
@@ -1,0 +1,55 @@
+# Phase 02 — Tích hợp vào WorkflowEngine + UI
+
+## Mục tiêu
+Cho mọi node gửi tin Zalo trong workflow đi qua `AccountSendQueue`, dùng delay cấu hình ở node.
+
+## Điểm chèn
+Trong `executeNode()` (`WorkflowEngineService.ts:989`), các case gửi tin:
+- `zalo.sendMessage` (ts:1010)
+- `zalo.sendImage` (ts:1102)
+- `zalo.sendFile` (ts:1126)
+- `zalo.sendMedia` (ts ~1240)
+
+Hiện mỗi case tự `await api.sendMessage(...)`. Bọc lại: thay vì gọi thẳng, đẩy qua
+`AccountSendQueue.getInstance().enqueue(ctx.pageId, () => <body gửi cũ>, minMs, maxMs)`.
+
+Account key = `ctx.pageId` (đã là zaloId của workflow, xem ts:701).
+
+## Cách bọc gọn nhất (DRY)
+Thêm 1 helper private trong class:
+```
+private enqueueSend<T>(cfg, ctx, task: () => Promise<T>): Promise<T> {
+  const minS = Number(cfg.sendDelayMinSeconds ?? 0);
+  const maxS = Number(cfg.sendDelayMaxSeconds ?? 0);
+  return AccountSendQueue.getInstance().enqueue(
+    ctx.pageId, task, minS * 1000, maxS * 1000
+  );
+}
+```
+Mỗi case gửi: `return this.enqueueSend(cfg, ctx, async () => { ...body gửi cũ... });`
+
+Lưu ý: body gửi cũ đã bao gồm typing-effect delay nội bộ (ts:1028-1034). Giữ nguyên trong task —
+những delay đó là hiệu ứng "đang gõ" trong 1 lần trả lời, còn queue delay là khoảng cách GIỮA các
+lần trả lời khác nhau của cùng account. Hai thứ độc lập.
+
+## Backward compatible
+- Node cũ chưa có `sendDelayMinSeconds` → `?? 0` → min=max=0 → queue chạy tuần tự nhưng KHÔNG chờ.
+  (Vẫn khác hành vi cũ 1 chút: giờ tuần tự thay vì song song. Đây là cải thiện mong muốn,
+   và không delay nên không chậm cảm nhận được.)
+
+## UI
+`NodeConfigPanel.tsx` — tìm block config của `zalo.sendMessage` (và các node gửi khác). Thêm 2 field:
+```
+{ key: 'sendDelayMinSeconds', label: 'Giãn cách gửi tối thiểu (giây)', type: 'number' }
+{ key: 'sendDelayMaxSeconds', label: 'Giãn cách gửi tối đa (giây)', type: 'number' }
+```
+Ghi chú UI: "Áp dụng khi nhiều khách nhắn cùng lúc trên cùng 1 tài khoản — tin gửi lần lượt, cách nhau khoảng này."
+
+`workflowConfig.ts` — thêm default `sendDelayMinSeconds: 1, sendDelayMaxSeconds: 3` cho
+`zalo.sendMessage`, `zalo.sendImage`, `zalo.sendFile`, `zalo.sendMedia`.
+
+## Todo
+- [ ] import AccountSendQueue vào WorkflowEngineService
+- [ ] thêm helper enqueueSend
+- [ ] bọc 4 case gửi tin
+- [ ] thêm UI field + default config

--- a/src/plans/260710-1432-per-account-reply-send-queue/phase-03-compile-test.md
+++ b/src/plans/260710-1432-per-account-reply-send-queue/phase-03-compile-test.md
@@ -1,0 +1,18 @@
+# Phase 03 — Compile-check + Test
+
+## Mục tiêu
+Đảm bảo không lỗi biên dịch, self-check pass.
+
+## Bước
+1. `npx tsc --noEmit -p tsconfig.json` — không lỗi type ở file đã sửa.
+   (Nếu repo lỗi sẵn ở file khác không liên quan → ghi nhận, không đụng.)
+2. Chạy test AccountSendQueue: `npx jest AccountSendQueue` (jest đã cấu hình sẵn, xem jest.config.js).
+3. Fake timers cho test delay → không phải chờ thật.
+
+## Success criteria
+- tsc pass (file mới + file sửa).
+- 4 test case pass.
+
+## Unresolved questions
+- Delay per-node hay per-account-global? → Đã chốt PER-NODE theo yêu cầu user (setting nằm ở task gửi tin trong wf).
+- FB send (fb.action.sendMessage) có cần queue không? → Phase này CHỈ làm Zalo (đúng scope user hỏi). FB để sau nếu cần.

--- a/src/plans/260710-1432-per-account-reply-send-queue/plan.md
+++ b/src/plans/260710-1432-per-account-reply-send-queue/plan.md
@@ -1,0 +1,43 @@
+# Plan: Hàng đợi gửi tin theo tài khoản (Per-Account Send Queue)
+
+## Vấn đề
+Khi nhiều khách nhắn cùng lúc vào **cùng 1 tài khoản Zalo**, `WorkflowEngineService.executeWorkflow()`
+được gọi song song (fire-and-forget, `WorkflowEngineService.ts:434`) và **không có giới hạn**.
+Các node gửi tin (`zalo.sendMessage`, `zalo.sendImage`, `zalo.sendFile`, `zalo.sendMedia`)
+gọi `api.sendMessage()` gần như đồng thời → 1 tài khoản bắn hàng loạt tin trong 1-2s → Zalo nghi spam → khóa.
+
+Debounce hiện có (`ts:366`) chỉ gom tin **cùng thread**, không kiểm soát tốc độ gửi **giữa các thread**.
+Token bucket trong `CRMQueueService` chỉ áp cho campaign outbound, KHÔNG áp cho auto-reply.
+
+## Giải pháp (KISS)
+Thêm module `AccountSendQueue`: mỗi `zaloId` một hàng đợi tuần tự (promise-chain).
+Mọi lời gọi gửi tin của workflow đi qua queue → tin ra **lần lượt**, giữa 2 tin của **cùng account**
+chờ delay ngẫu nhiên `min..max` giây (mặc định 1-3s). Các account khác nhau chạy **song song**.
+
+Delay cấu hình tại **node gửi tin** trong workflow (đúng yêu cầu user: "trong wf có task gửi tin thì
+có setting thời gian cách nhau"). Nhiều workflow cùng 1 account → chung 1 hàng đợi → không đụng nhau.
+
+## Phạm vi
+- CHỈ đụng đường gửi tin Zalo trong workflow auto-reply.
+- KHÔNG đụng `CRMQueueService` (đã có cơ chế riêng).
+- KHÔNG đổi debounce logic.
+
+## Phases
+| Phase | File | Nội dung | Status |
+|-------|------|----------|--------|
+| 01 | [phase-01](phase-01-account-send-queue-module.md) | Module `AccountSendQueue` + self-check | ☐ |
+| 02 | [phase-02](phase-02-integrate-workflow-engine.md) | Tích hợp vào các node gửi tin + UI setting delay | ☐ |
+| 03 | [phase-03](phase-03-compile-test.md) | Compile-check + test | ☐ |
+
+## Files sẽ đụng
+- **TẠO:** `src/services/workflow/AccountSendQueue.ts`
+- **TẠO:** `src/services/workflow/__tests__/AccountSendQueue.test.ts`
+- **SỬA:** `src/services/workflow/WorkflowEngineService.ts` (bọc các node gửi tin qua queue)
+- **SỬA:** `src/ui/components/workflow/NodeConfigPanel.tsx` (thêm 2 ô delayMin/delayMax cho node gửi tin)
+- **SỬA:** `src/ui/components/workflow/workflowConfig.ts` (default config)
+
+## Success criteria
+- 200 tin từ 200 thread cùng 1 account → gửi tuần tự, mỗi tin cách 1-3s (không bắn đồng thời).
+- 2 account khác nhau → 2 hàng đợi song song, không cản nhau.
+- `tsc` không lỗi. Self-check pass.
+- Không đổi hành vi khi delay = 0 (backward compatible).

--- a/src/services/crm/CRMQueueService.ts
+++ b/src/services/crm/CRMQueueService.ts
@@ -5,6 +5,7 @@ import Logger from '../../utils/Logger';
 import * as fs from 'fs';
 import * as path from 'path';
 import imageSize from 'image-size';
+import { parseMarkup } from './message-markup';
 
 /**
  * CRMQueueService - chạy trong main process
@@ -254,7 +255,7 @@ class CRMQueueService {
             mixedGroupIds = mixedConfig.group_ids || [];
 
             // ── Multi-block template support ───────────────────────────────
-            type ContentBlock = { id: string; text: string; images: string[] };
+            type ContentBlock = { id: string; text: string; images: string[]; tagAll?: boolean; tagAllText?: string };
             const parseContentBlocks = (raw: string): { blocks: ContentBlock[]; mode: 'random' | 'all' } => {
                 try {
                     const p = JSON.parse(raw);
@@ -276,9 +277,21 @@ class CRMQueueService {
             // Helper: send one block (text + images)
             const sendBlock = async (block: ContentBlock, threadId: string, threadType: number): Promise<any[]> => {
                 const responses: any[] = [];
-                const text = substitute(block.text || '');
-                if (text.trim()) {
-                    const resp = await (conn.api as any).sendMessage({ msg: text }, threadId, threadType);
+                const { text: cleanText, styles } = parseMarkup(substitute(block.text || ''));
+                if (cleanText.trim()) {
+                    const content: any = { msg: cleanText };
+                    let finalStyles = styles;
+                    // Tag-all chỉ có nghĩa trong nhóm (threadType 1); user thường (0) bỏ qua.
+                    if (threadType === 1 && block.tagAll) {
+                        const label = '@' + ((block.tagAllText || 'all').trim() || 'all');
+                        const prefix = label + ' ';
+                        content.msg = prefix + cleanText;
+                        // uid "-1" = mention toàn nhóm; len phải bao đúng đoạn label (đã trừ dấu cách)
+                        content.mentions = [{ pos: 0, uid: '-1', len: label.length }];
+                        finalStyles = styles.map(s => ({ ...s, start: s.start + prefix.length }));
+                    }
+                    if (finalStyles.length) content.styles = finalStyles;
+                    const resp = await (conn.api as any).sendMessage(content, threadId, threadType);
                     responses.push(resp);
                 }
                 const imgs = (block.images || []).filter(Boolean);

--- a/src/services/crm/message-markup.ts
+++ b/src/services/crm/message-markup.ts
@@ -1,0 +1,77 @@
+// Parser markup BBCode-style → định dạng zca-js (styles) cho tin nhắn Zalo.
+//
+// Vì {name} được thay lúc gửi (mỗi contact tên dài/ngắn khác nhau), style KHÔNG thể
+// lưu theo offset tuyệt đối. Thay vào đó lưu thẻ inline trong text và parse SAU khi
+// đã substitute → offset luôn khớp với text thật gửi đi.
+
+/** Bảng ánh xạ thẻ → mã TextStyle của zca-js (dist/apis/sendMessage: enum TextStyle). */
+const TAG_TO_STYLE: Record<string, string> = {
+    b: 'b',            // Bold
+    i: 'i',            // Italic
+    u: 'u',            // Underline
+    s: 's',            // StrikeThrough
+    red: 'c_db342e',   // Red
+    orange: 'c_f27806',// Orange
+    yellow: 'c_f7b503',// Yellow
+    green: 'c_15a85f', // Green
+    big: 'f_18',       // Big
+    small: 'f_13',     // Small
+};
+
+export interface MarkupStyle {
+    start: number;
+    len: number;
+    st: string;
+}
+
+export interface ParsedMarkup {
+    text: string;
+    styles: MarkupStyle[];
+}
+
+const TAG_RE = /\[(\/?)([a-z]+)\]/gi;
+
+/**
+ * Tách thẻ markup khỏi text và sinh danh sách style theo offset trên text sạch.
+ * - Thẻ lồng nhau OK (sinh nhiều style cùng range — zca-js chấp nhận).
+ * - Thẻ lạ / không khớp cặp mở-đóng → giữ nguyên như text thường (không crash).
+ */
+export function parseMarkup(raw: string): ParsedMarkup {
+    if (!raw) return { text: '', styles: [] };
+
+    const styles: MarkupStyle[] = [];
+    const openStack: { tag: string; start: number }[] = [];
+    let text = '';
+    let lastIndex = 0;
+    let m: RegExpExecArray | null;
+
+    TAG_RE.lastIndex = 0;
+    while ((m = TAG_RE.exec(raw)) !== null) {
+        const isClose = m[1] === '/';
+        const tag = m[2].toLowerCase();
+
+        // Thẻ không nằm trong bảng → coi như text thường, bỏ qua (giữ nguyên literal).
+        if (!(tag in TAG_TO_STYLE)) continue;
+
+        // Nối phần text đứng trước thẻ vào output sạch.
+        text += raw.slice(lastIndex, m.index);
+        lastIndex = TAG_RE.lastIndex;
+
+        if (!isClose) {
+            openStack.push({ tag, start: text.length });
+        } else {
+            // Tìm thẻ mở gần nhất cùng loại (LIFO).
+            let found = -1;
+            for (let i = openStack.length - 1; i >= 0; i--) {
+                if (openStack[i].tag === tag) { found = i; break; }
+            }
+            if (found === -1) continue; // đóng không có mở → bỏ qua
+            const open = openStack.splice(found, 1)[0];
+            const len = text.length - open.start;
+            if (len > 0) styles.push({ start: open.start, len, st: TAG_TO_STYLE[tag] });
+        }
+    }
+    text += raw.slice(lastIndex);
+
+    return { text, styles };
+}

--- a/src/services/database/DatabaseService.ts
+++ b/src/services/database/DatabaseService.ts
@@ -674,7 +674,6 @@ class DatabaseService {
         try { this.exec(`ALTER TABLE crm_campaigns ADD COLUMN friend_request_message TEXT NOT NULL DEFAULT ''`); } catch {}
         try { this.exec(`ALTER TABLE crm_campaigns ADD COLUMN campaign_type TEXT NOT NULL DEFAULT 'message'`); } catch {}
         try { this.exec(`ALTER TABLE crm_campaigns ADD COLUMN mixed_config TEXT NOT NULL DEFAULT '{}'`); } catch {}
-        try { this.exec(`ALTER TABLE crm_campaign_contacts ADD COLUMN phone TEXT NOT NULL DEFAULT ''`); } catch {}
 
         this.exec(`
             CREATE TABLE IF NOT EXISTS crm_campaign_contacts (
@@ -694,6 +693,8 @@ class DatabaseService {
             CREATE INDEX IF NOT EXISTS idx_crm_cc_campaign ON crm_campaign_contacts(campaign_id, status);
             CREATE INDEX IF NOT EXISTS idx_crm_cc_owner ON crm_campaign_contacts(owner_zalo_id, status);
         `);
+        // Migration phải chạy SAU khi bảng đã tồn tại (DB mới sẽ throw nếu ALTER trước CREATE)
+        try { this.exec(`ALTER TABLE crm_campaign_contacts ADD COLUMN phone TEXT NOT NULL DEFAULT ''`); } catch {}
 
         this.exec(`
             CREATE TABLE IF NOT EXISTS crm_send_log (

--- a/src/services/http/HttpClientService.ts
+++ b/src/services/http/HttpClientService.ts
@@ -907,6 +907,11 @@ class HttpClientService {
             if (hostname.endsWith('.loca.lt') || hostname.endsWith('.localtunnel.me')) {
                 return { 'bypass-tunnel-reminder': 'true' };
             }
+            // ngrok free domains chèn trang cảnh báo trình duyệt → header này bỏ qua,
+            // trả JSON trực tiếp thay vì HTML interstitial.
+            if (hostname.endsWith('.ngrok-free.dev') || hostname.endsWith('.ngrok-free.app') || hostname.endsWith('.ngrok.app') || hostname.endsWith('.ngrok.io')) {
+                return { 'ngrok-skip-browser-warning': 'true' };
+            }
         } catch { /* ignore */ }
         return {};
     }

--- a/src/services/http/HttpRelayService.ts
+++ b/src/services/http/HttpRelayService.ts
@@ -7,7 +7,7 @@ import EmployeeService from '../employee/EmployeeService';
 import DatabaseService from '../database/DatabaseService';
 import EventBroadcaster from '../event/EventBroadcaster';
 import ConnectionManager from '../../utils/ConnectionManager';
-import TunnelService from '../tunnel/TunnelService';
+import TunnelService, { TunnelOptions, TunnelProvider } from '../tunnel/TunnelService';
 import SocketIOService from '../socket/SocketIOService';
 import { handlers as restHandlers } from './handlers/RestApiHandlers';
 import { handleMediaRequest as handleMediaFileServe } from './handlers/MediaHandler';
@@ -95,6 +95,9 @@ class HttpRelayService {
     /** Tunnel state */
     private tunnelActive = false;
     private tunnelUrl: string | null = null;
+
+    /** powerSaveBlocker id — chặn Mac/OS ngủ khi relay đang phục vụ nhân viên */
+    private powerSaveId: number | null = null;
 
     /**
      * Pending employee sender info: msgId → employee data.
@@ -347,6 +350,7 @@ class HttpRelayService {
             return new Promise((resolve) => {
                 this.httpServer!.listen(this.port, () => {
                     this.running = true;
+                    this.startPowerSaveBlocker();
                     Logger.log(`[HttpRelayService] ✅ Server started on port ${this.port}`);
                     resolve({ success: true, port: this.port });
                 });
@@ -392,6 +396,7 @@ class HttpRelayService {
             this.employees.clear();
             this.running = false;
             this.pinnedDbPath = null;
+            this.stopPowerSaveBlocker();
             EmployeeService.getInstance().unpinDb();
             Logger.log('[HttpRelayService] Server stopped');
             return { success: true };
@@ -2219,7 +2224,7 @@ class HttpRelayService {
             return { success: false, error: 'Relay server chưa được bật' };
         }
         try {
-            const url = await TunnelService.start(this.port, 'Employee Relay');
+            const url = await TunnelService.start(this.port, 'Employee Relay', this.getTunnelOptions());
             this.tunnelActive = true;
             this.tunnelUrl = url;
             Logger.log(`[HttpRelayService] 🌐 Tunnel active: ${url}`);
@@ -2252,6 +2257,46 @@ class HttpRelayService {
 
     public getTunnelStatus(): { active: boolean; tunnelUrl: string | null } {
         return { active: this.tunnelActive, tunnelUrl: this.tunnelUrl };
+    }
+
+    /** Đọc provider config (cloudflare mặc định, hoặc ngrok static domain) từ DB. */
+    private getTunnelOptions(): TunnelOptions {
+        try {
+            const db = DatabaseService.getInstance();
+            const provider = (db.getSetting('relay_tunnel_provider') as TunnelProvider) || 'cloudflare';
+            if (provider === 'ngrok') {
+                return {
+                    provider: 'ngrok',
+                    authtoken: db.getSetting('relay_ngrok_authtoken') || undefined,
+                    domain: db.getSetting('relay_ngrok_domain') || undefined,
+                };
+            }
+        } catch (err: any) {
+            Logger.warn(`[HttpRelayService] getTunnelOptions failed: ${err.message}`);
+        }
+        return { provider: 'cloudflare' };
+    }
+
+    /** Chặn OS ngủ (idle sleep) khi relay chạy — nhân viên vẫn truy cập được. */
+    private startPowerSaveBlocker(): void {
+        if (this.powerSaveId !== null) return;
+        try {
+            const { powerSaveBlocker } = require('electron');
+            this.powerSaveId = powerSaveBlocker.start('prevent-app-suspension');
+            Logger.log(`[HttpRelayService] powerSaveBlocker started (id ${this.powerSaveId})`);
+        } catch (err: any) {
+            Logger.warn(`[HttpRelayService] powerSaveBlocker start failed: ${err.message}`);
+        }
+    }
+
+    private stopPowerSaveBlocker(): void {
+        if (this.powerSaveId === null) return;
+        try {
+            const { powerSaveBlocker } = require('electron');
+            powerSaveBlocker.stop(this.powerSaveId);
+            Logger.log(`[HttpRelayService] powerSaveBlocker stopped (id ${this.powerSaveId})`);
+        } catch { /* ignore */ }
+        this.powerSaveId = null;
     }
 
     // ─── Event relay (push to employees) ──────────────────────────────

--- a/src/services/tunnel/TunnelService.ts
+++ b/src/services/tunnel/TunnelService.ts
@@ -44,10 +44,27 @@ try {
   Logger.warn('[TunnelService] cloudflared package not found');
 }
 
+// ngrok provider (optional). Cấp static domain cố định — dùng cho relay nhân viên.
+let ngrok: any = null;
+try {
+  ngrok = require('@ngrok/ngrok');
+} catch {
+  Logger.warn('[TunnelService] @ngrok/ngrok package not found');
+}
+
+export type TunnelProvider = 'cloudflare' | 'ngrok';
+
+export interface TunnelOptions {
+  provider?: TunnelProvider;
+  authtoken?: string;
+  domain?: string;
+}
+
 // ─── Multi-tunnel store ──────────────────────────────────────────────────────
 
 interface TunnelEntry {
-  tunnel: any;
+  tunnel: any;          // cloudflared Tunnel hoặc ngrok listener
+  provider: TunnelProvider;
   url: string | null;
   label: string;
   onChangeCbs: Set<(url: string | null) => void>;
@@ -59,14 +76,20 @@ const tunnels = new Map<number, TunnelEntry>();
 
 export const TunnelService = {
   /**
-   * Start a Cloudflare Quick Tunnel pointing to a local port.
+   * Start a tunnel pointing to a local port.
+   * Provider mặc định là 'cloudflare' (Quick Tunnel, URL random). Truyền
+   * opts.provider='ngrok' + authtoken/domain để có URL cố định.
    * Multiple tunnels can run concurrently (keyed by port).
    * Returns the public URL.
    */
-  async start(port: number, label?: string): Promise<string> {
+  async start(port: number, label?: string, opts?: TunnelOptions): Promise<string> {
     // If a tunnel already exists for this port, stop it first before restarting
     if (tunnels.has(port)) {
       await this.stop(port);
+    }
+
+    if (opts?.provider === 'ngrok') {
+      return this._startNgrok(port, label, opts);
     }
 
     if (!Tunnel || !bin || !install) {
@@ -102,6 +125,7 @@ export const TunnelService = {
 
           const entry: TunnelEntry = {
             tunnel,
+            provider: 'cloudflare',
             url,
             label: label || `Port ${port}`,
             onChangeCbs: new Set(),
@@ -141,13 +165,55 @@ export const TunnelService = {
   },
 
   /**
+   * Start an ngrok tunnel với static domain cố định.
+   * Yêu cầu authtoken (bắt buộc) và domain (tùy chọn — không có domain thì
+   * ngrok cấp URL random như cloudflare, chỉ khác provider).
+   */
+  async _startNgrok(port: number, label?: string, opts?: TunnelOptions): Promise<string> {
+    if (!ngrok) {
+      throw new Error('Chưa cài gói @ngrok/ngrok. Chạy: npm install @ngrok/ngrok');
+    }
+    if (!opts?.authtoken) {
+      throw new Error('Thiếu ngrok authtoken. Nhập trong Cài đặt → Tunnel.');
+    }
+
+    Logger.log(`[TunnelService] Starting ngrok tunnel on port ${port}${opts.domain ? ` (${opts.domain})` : ''}...`);
+
+    const listener = await ngrok.forward({
+      addr: port,
+      authtoken: opts.authtoken,
+      ...(opts.domain ? { domain: opts.domain } : {}),
+    });
+    const url = listener.url();
+
+    const entry: TunnelEntry = {
+      tunnel: listener,
+      provider: 'ngrok',
+      url,
+      label: label || `Port ${port}`,
+      onChangeCbs: tunnels.get(port)?.onChangeCbs ?? new Set(),
+    };
+    tunnels.set(port, entry);
+
+    Logger.log(`[TunnelService] ✅ Tunnel active [${port}]: ${url} (ngrok${label ? ` - ${label}` : ''})`);
+    TunnelService._notifyChange(port, url);
+    return url;
+  },
+
+  /**
    * Stop a specific tunnel by port.
    * Usage: TunnelService.stop(9888)
    */
   async stop(port: number): Promise<void> {
     const entry = tunnels.get(port);
     if (entry) {
-      try { entry.tunnel.stop(); } catch { /* ignore */ }
+      try {
+        if (entry.provider === 'ngrok') {
+          await entry.tunnel?.close();   // ngrok listener
+        } else {
+          entry.tunnel?.stop();          // cloudflared
+        }
+      } catch { /* ignore */ }
       tunnels.delete(port);
       TunnelService._notifyChange(port, null);
       Logger.log(`[TunnelService] Stopped tunnel [${port}]${entry.label ? ` (${entry.label})` : ''}`);
@@ -202,7 +268,7 @@ export const TunnelService = {
     if (!entry) {
       // Create a placeholder entry so we don't lose the callback
       // when the tunnel hasn't started yet. It will be replaced on start().
-      entry = { tunnel: null as any, url: null, label: `Port ${port}`, onChangeCbs: new Set() };
+      entry = { tunnel: null as any, provider: 'cloudflare', url: null, label: `Port ${port}`, onChangeCbs: new Set() };
       tunnels.set(port, entry);
     }
     entry.onChangeCbs.add(cb);

--- a/src/ui/components/crm/CRMPage.tsx
+++ b/src/ui/components/crm/CRMPage.tsx
@@ -271,8 +271,12 @@ export default function CRMPage() {
 
   // ── Campaign actions ─────────────────────────────────────────────────────
   const handleCreateCampaign = async (data: any) => {
-    if (!activeAccountId) return;
-    const res = await DataAccessor.saveCRMCampaign({ zaloId: activeAccountId, campaign: data });
+    // activeAccountId có thể còn null nếu bấm ngay lúc khởi động (account chưa auto-select xong).
+    // Fallback về account đầu tiên trong store để không mất thao tác tạo.
+    const acctId = activeAccountId || accounts?.[0]?.zalo_id;
+    if (!acctId) return;
+    if (!activeAccountId) setActiveAccount(acctId);
+    const res = await DataAccessor.saveCRMCampaign({ zaloId: acctId, campaign: data });
     if (res?.success) {
       await loadCampaigns();
       store.setActiveCampaign(res.id);

--- a/src/ui/components/crm/campaigns/CampaignCreateModal.tsx
+++ b/src/ui/components/crm/campaigns/CampaignCreateModal.tsx
@@ -4,6 +4,7 @@ import ipc from '@/lib/ipc';
 import { toLocalMediaUrl } from '@/lib/localMedia';
 import { Spinner } from '@/components/common/PageLoading';
 import { AlertIcon, ChartIcon, ChatIcon, ClipboardListIcon, EditIcon, RocketIcon, SendIcon, ShuffleIcon, UserCheckIcon, UsersIcon } from '@/components/common/icons';
+import { parseMarkup } from '../../../../services/crm/message-markup';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -12,7 +13,7 @@ type MixedAction  = 'message' | 'friend_request' | 'invite_to_groups';
 type SendMode     = 'random' | 'all';
 
 export interface MixedConfig   { actions: MixedAction[]; group_ids?: string[]; }
-export interface ContentBlock  { id: string; text: string; images: string[]; }
+export interface ContentBlock  { id: string; text: string; images: string[]; tagAll?: boolean; tagAllText?: string; }
 export interface ContentConfig { mode: SendMode; blocks: ContentBlock[]; }
 
 interface CampaignFormData {
@@ -343,6 +344,45 @@ function GroupPicker({
   );
 }
 
+// ── Markup Preview ────────────────────────────────────────────────────────────
+
+// Render text có markup thành các <span> có style, khớp với cách zca-js hiển thị.
+const STYLE_CSS: Record<string, React.CSSProperties> = {
+  b: { fontWeight: 700 },
+  i: { fontStyle: 'italic' },
+  u: { textDecoration: 'underline' },
+  s: { textDecoration: 'line-through' },
+  c_db342e: { color: '#db342e' },
+  c_f27806: { color: '#f27806' },
+  c_f7b503: { color: '#f7b503' },
+  c_15a85f: { color: '#15a85f' },
+  f_18: { fontSize: '1.15em' },
+  f_13: { fontSize: '0.85em' },
+};
+
+function MarkupPreview({ text }: { text: string }) {
+  const { text: clean, styles } = parseMarkup(text);
+  if (!styles.length) return <span className="text-gray-300">{clean}</span>;
+  // Gộp style theo từng ký tự rồi cắt thành đoạn liên tiếp cùng style.
+  const css: React.CSSProperties[] = Array.from({ length: clean.length }, () => ({}));
+  for (const s of styles) {
+    const props = STYLE_CSS[s.st] || {};
+    for (let i = s.start; i < s.start + s.len && i < clean.length; i++) {
+      Object.assign(css[i], props);
+    }
+  }
+  const spans: React.ReactNode[] = [];
+  let i = 0;
+  while (i < clean.length) {
+    let j = i + 1;
+    const key = JSON.stringify(css[i]);
+    while (j < clean.length && JSON.stringify(css[j]) === key) j++;
+    spans.push(<span key={i} style={css[i]}>{clean.slice(i, j)}</span>);
+    i = j;
+  }
+  return <span className="text-gray-300">{spans}</span>;
+}
+
 // ── Block Editor ──────────────────────────────────────────────────────────────
 
 function BlockEditor({
@@ -360,6 +400,20 @@ function BlockEditor({
     const e = ta.selectionEnd ?? block.text.length;
     onUpdate({ text: block.text.slice(0, s) + v + block.text.slice(e) });
     setTimeout(() => { ta.focus(); ta.setSelectionRange(s + v.length, s + v.length); }, 0);
+  };
+
+  // Bọc đoạn đang bôi đen bằng cặp thẻ markup ([b]…[/b], [red]…[/red]…).
+  // Không bôi đen thì chèn cặp thẻ rỗng và đặt con trỏ vào giữa.
+  const wrapSelection = (tag: string) => {
+    const ta = taRef.current;
+    const open = `[${tag}]`, close = `[/${tag}]`;
+    if (!ta) { onUpdate({ text: `${block.text}${open}${close}` }); return; }
+    const s = ta.selectionStart ?? block.text.length;
+    const e = ta.selectionEnd ?? block.text.length;
+    const sel = block.text.slice(s, e);
+    onUpdate({ text: block.text.slice(0, s) + open + sel + close + block.text.slice(e) });
+    const caret = s + open.length + sel.length;
+    setTimeout(() => { ta.focus(); ta.setSelectionRange(caret, caret); }, 0);
   };
 
   const pickImages = async () => {
@@ -383,6 +437,28 @@ function BlockEditor({
         ))}
       </div>
 
+      {/* Toolbar định dạng */}
+      <div className="flex items-center gap-1 flex-wrap flex-shrink-0">
+        <button type="button" onClick={() => wrapSelection('b')} title="In đậm"
+          className="text-[12px] font-bold w-6 h-6 rounded border border-gray-600 text-gray-300 hover:bg-gray-700 transition-colors">B</button>
+        <button type="button" onClick={() => wrapSelection('i')} title="In nghiêng"
+          className="text-[12px] italic w-6 h-6 rounded border border-gray-600 text-gray-300 hover:bg-gray-700 transition-colors">I</button>
+        <button type="button" onClick={() => wrapSelection('u')} title="Gạch chân"
+          className="text-[12px] underline w-6 h-6 rounded border border-gray-600 text-gray-300 hover:bg-gray-700 transition-colors">U</button>
+        <button type="button" onClick={() => wrapSelection('s')} title="Gạch ngang"
+          className="text-[12px] line-through w-6 h-6 rounded border border-gray-600 text-gray-300 hover:bg-gray-700 transition-colors">S</button>
+        <span className="w-px h-4 bg-gray-600 mx-0.5" />
+        {([['red','#db342e'],['orange','#f27806'],['yellow','#f7b503'],['green','#15a85f']] as const).map(([tag, hex]) => (
+          <button key={tag} type="button" onClick={() => wrapSelection(tag)} title={`Màu ${tag}`}
+            className="w-5 h-5 rounded-full border border-gray-500 hover:scale-110 transition-transform" style={{ background: hex }} />
+        ))}
+        <span className="w-px h-4 bg-gray-600 mx-0.5" />
+        <button type="button" onClick={() => wrapSelection('big')} title="Cỡ lớn"
+          className="text-[13px] font-semibold px-1.5 h-6 rounded border border-gray-600 text-gray-300 hover:bg-gray-700 transition-colors">A+</button>
+        <button type="button" onClick={() => wrapSelection('small')} title="Cỡ nhỏ"
+          className="text-[10px] px-1.5 h-6 rounded border border-gray-600 text-gray-300 hover:bg-gray-700 transition-colors">A-</button>
+      </div>
+
       {/* Textarea - takes most space */}
       <textarea
         ref={taRef}
@@ -391,6 +467,31 @@ function BlockEditor({
         placeholder={'Soạn nội dung tin nhắn...\nDùng {name} để chèn tên người nhận'}
         className="flex-1 min-h-0 w-full bg-gray-800 border border-gray-600 rounded-xl px-3 py-2.5 text-sm text-gray-200 placeholder-gray-500 focus:outline-none focus:border-blue-500 resize-none transition-colors"
       />
+
+      {/* Xem trước định dạng */}
+      {block.text.includes('[') && (
+        <div className="flex-shrink-0 bg-gray-800/50 border border-gray-700 rounded-lg px-3 py-2">
+          <div className="text-[10px] text-gray-500 mb-1">Xem trước</div>
+          <div className="text-sm whitespace-pre-wrap break-words"><MarkupPreview text={block.text} /></div>
+        </div>
+      )}
+
+      {/* Tag @all khi gửi nhóm */}
+      <label className="flex items-center gap-2 flex-shrink-0 cursor-pointer text-xs text-gray-400 select-none flex-wrap">
+        <input type="checkbox" checked={!!block.tagAll} onChange={e => onUpdate({ tagAll: e.target.checked })}
+          className="accent-blue-500 w-3.5 h-3.5" />
+        Tag toàn nhóm khi gửi vào nhóm
+        {block.tagAll && (
+          <span className="flex items-center gap-1" onClick={e => e.preventDefault()}>
+            <span className="font-mono text-blue-400">@</span>
+            <input type="text" value={block.tagAllText ?? 'all'}
+              onChange={e => onUpdate({ tagAllText: e.target.value })}
+              placeholder="all"
+              className="w-28 bg-gray-800 border border-gray-700 rounded px-1.5 py-0.5 font-mono text-blue-400 text-xs focus:outline-none focus:border-blue-500" />
+          </span>
+        )}
+        <span className="text-gray-500">(bỏ qua với chat cá nhân)</span>
+      </label>
 
       {/* Images */}
       <div className="flex-shrink-0">

--- a/src/ui/components/crm/campaigns/TargetSelector.tsx
+++ b/src/ui/components/crm/campaigns/TargetSelector.tsx
@@ -27,6 +27,11 @@ interface TargetSelectorProps {
 
 type SelectMode = 'manual' | 'by_label' | 'friends_only' | 'groups_only' | 'by_phone' | 'by_uid';
 
+/** Nhãn Zalo lưu ID nhóm với tiền tố "g" (vd "g4579..."); contact_id trong CRM thì không. Bỏ tiền tố để so khớp. */
+function stripGroupPrefix(id: string): string {
+  return id.startsWith('g') ? id.slice(1) : id;
+}
+
 /** Normalize a phone string: remove spaces/dashes, convert +84/84 prefix → 0 */
 function normalizePhone(raw: string): string {
   let s = raw.replace(/[\s\-().]/g, '');
@@ -40,7 +45,7 @@ export default function TargetSelector({ zaloId, allLabels, localLabels, localLa
   const [mode, setMode] = useState<SelectMode>('manual');
   const [selectedZaloLabelIds, setSelectedZaloLabelIds] = useState<number[]>([]);
   const [selectedLocalLabelIds, setSelectedLocalLabelIds] = useState<number[]>([]);
-  const [manualSelected, setManualSelected] = useState<Set<string>>(new Set());
+  const [manualSelected, setManualSelected] = useState<Set<string>>(new Set());  // Với mode lọc (nhóm/bạn bè/nhãn) mọi item được chọn sẵn; user có thể bỏ chọn từng cái → lưu ở đây.
   const [search, setSearch] = useState('');
   const [allContacts, setAllContacts] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
@@ -103,6 +108,9 @@ export default function TargetSelector({ zaloId, allLabels, localLabels, localLa
       .finally(() => setLoading(false));
   }, [zaloId]);
 
+  // Đổi mode/nhãn → reset danh sách đã chọn để không giữ nhầm sang tập khác.
+  useEffect(() => { setManualSelected(new Set()); }, [mode, selectedZaloLabelIds, selectedLocalLabelIds]);
+
   // Available = not already in campaign
   const available = useMemo(() =>
     (allContacts || []).filter(c => !existingContactIds.has(c.contact_id)),
@@ -115,13 +123,16 @@ export default function TargetSelector({ zaloId, allLabels, localLabels, localLa
     if (mode === 'friends_only') list = list.filter(c => c.is_friend === 1);
     if (mode === 'groups_only') list = list.filter(c => c.contact_type === 'group');
     if (mode === 'by_label') {
-      // Filter by selected Zalo labels
+      // Filter by selected Zalo labels.
+      // Nhãn Zalo lưu ID nhóm có tiền tố "g" (vd "g4579..."), còn contact_id trong CRM
+      // không có tiền tố → chuẩn hóa cả hai đầu trước khi so khớp.
       if (selectedZaloLabelIds.length > 0) {
-        list = list.filter(c =>
-          selectedZaloLabelIds.every(labelId =>
-            allLabels.find(l => l.id === labelId)?.conversations?.includes(c.contact_id)
-          )
-        );
+        list = list.filter(c => {
+          const cid = stripGroupPrefix(c.contact_id);
+          return selectedZaloLabelIds.every(labelId =>
+            allLabels.find(l => l.id === labelId)?.conversations?.some(conv => stripGroupPrefix(conv) === cid)
+          );
+        });
       }
       // Filter by selected Local labels
       if (selectedLocalLabelIds.length > 0 && effectiveThreadMap) {
@@ -262,8 +273,8 @@ export default function TargetSelector({ zaloId, allLabels, localLabels, localLa
           return true;
         });
     }
-    if (mode === 'manual') return available.filter(c => manualSelected.has(c.contact_id));
-    return filtered;
+    // Mode manual & mode lọc theo nhãn: mặc định không tích, user tự chọn từng liên hệ.
+    return filtered.filter(c => manualSelected.has(c.contact_id));
   }, [mode, available, manualSelected, filtered, phoneList, phoneResolved, uidList, uidResolved, existingContactIds]);
 
   const toggleManual = (id: string) => {
@@ -651,11 +662,9 @@ export default function TargetSelector({ zaloId, allLabels, localLabels, localLa
                   placeholder="Tìm tên, SĐT, UID..."
                   className="w-full bg-gray-700 border border-gray-600 rounded-full pl-7 pr-3 py-1.5 text-xs text-white placeholder-gray-500 focus:outline-none focus:border-blue-500" />
               </div>
-              {mode === 'manual' && (
-                <button onClick={selectAllFiltered} className="text-xs text-blue-400 hover:text-blue-300 flex-shrink-0">
-                  Chọn tất cả ({filtered.length})
-                </button>
-              )}
+              <button onClick={selectAllFiltered} className="text-xs text-blue-400 hover:text-blue-300 flex-shrink-0">
+                Chọn tất cả ({filtered.length})
+              </button>
             </div>
 
             {/* Contact list */}
@@ -671,20 +680,18 @@ export default function TargetSelector({ zaloId, allLabels, localLabels, localLa
               ) : (
                 filtered.map(c => {
                   const name = c.alias || c.display_name || c.contact_id;
-                  const isChecked = mode === 'manual' ? manualSelected.has(c.contact_id) : true;
-                  const contactLabels = allLabels.filter(l => l.conversations?.includes(c.contact_id));
+                  const isChecked = manualSelected.has(c.contact_id);
+                  const cidNoPrefix = stripGroupPrefix(c.contact_id);
+                  const contactLabels = allLabels.filter(l => l.conversations?.some(conv => stripGroupPrefix(conv) === cidNoPrefix));
                   const contactLocalLabelIds = effectiveThreadMap[c.contact_id] || [];
                   const contactLocalLabels = effectiveLocalLabels.filter(l => contactLocalLabelIds.includes(l.id));
                   return (
                     <label key={c.contact_id}
-                      className={`flex items-center gap-2.5 px-4 py-2.5 border-b border-gray-700/50 transition-colors ${
-                        mode === 'manual' ? 'cursor-pointer hover:bg-gray-700/40' : 'cursor-default'
-                      } ${isChecked && mode !== 'manual' ? 'bg-blue-500/5' : ''}`}>
-                      {mode === 'manual'
-                        ? <input type="checkbox" checked={isChecked} onChange={() => toggleManual(c.contact_id)} className="accent-blue-500 flex-shrink-0" />
-                        : <span className="w-4 h-4 rounded-full bg-blue-600/30 border border-blue-500/50 flex items-center justify-center flex-shrink-0">
-                            <span className="text-blue-400 text-[9px]">✓</span>
-                          </span>}
+                      className={`flex items-center gap-2.5 px-4 py-2.5 border-b border-gray-700/50 transition-colors cursor-pointer hover:bg-gray-700/40 ${
+                        isChecked ? 'bg-blue-500/5' : ''
+                      }`}>
+                      <input type="checkbox" checked={isChecked} className="accent-blue-500 flex-shrink-0"
+                        onChange={() => toggleManual(c.contact_id)} />
                       {/* Avatar */}
                       <div className="w-8 h-8 rounded-full overflow-hidden flex-shrink-0">
                         {c.avatar

--- a/src/ui/components/settings/LogViewer.tsx
+++ b/src/ui/components/settings/LogViewer.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { ipc } from '@/lib/ipc';
+
+type LogLevel = 'log' | 'error' | 'warn' | 'info' | 'debug';
+interface LogEntry { ts: number; level: LogLevel; msg: string; }
+
+const LEVEL_STYLE: Record<LogLevel, string> = {
+  error: 'text-red-400',
+  warn:  'text-yellow-400',
+  info:  'text-blue-400',
+  debug: 'text-purple-400',
+  log:   'text-gray-300',
+};
+
+const LEVEL_LABEL: Record<LogLevel, string> = {
+  error: 'LỖI', warn: 'CẢNH BÁO', info: 'INFO', debug: 'DEBUG', log: 'LOG',
+};
+
+const MAX_RENDER = 2000; // khớp buffer main
+
+export default function LogViewer() {
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [filter, setFilter] = useState<'all' | LogLevel>('all');
+  const [search, setSearch] = useState('');
+  const [autoScroll, setAutoScroll] = useState(true);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // Nạp buffer sẵn có + lắng nghe log mới
+  useEffect(() => {
+    ipc.logs?.getBuffer().then((buf: LogEntry[]) => setEntries(buf || [])).catch(() => {});
+    const unsub = ipc.on?.('log:entry', (entry: LogEntry) => {
+      setEntries(prev => {
+        const next = [...prev, entry];
+        return next.length > MAX_RENDER ? next.slice(next.length - MAX_RENDER) : next;
+      });
+    });
+    return () => { unsub?.(); };
+  }, []);
+
+  useEffect(() => {
+    if (autoScroll) bottomRef.current?.scrollIntoView({ behavior: 'auto' });
+  }, [entries, autoScroll]);
+
+  const visible = entries.filter(e => {
+    if (filter !== 'all' && e.level !== filter) return false;
+    if (search.trim() && !e.msg.toLowerCase().includes(search.toLowerCase())) return false;
+    return true;
+  });
+
+  const fmt = (ts: number) => new Date(ts).toLocaleTimeString('vi-VN', { hour12: false }) +
+    '.' + String(ts % 1000).padStart(3, '0');
+
+  const handleClear = async () => {
+    await ipc.logs?.clear().catch(() => {});
+    setEntries([]);
+  };
+
+  const handleCopy = () => {
+    const text = visible.map(e => `[${fmt(e.ts)}] [${LEVEL_LABEL[e.level]}] ${e.msg}`).join('\n');
+    navigator.clipboard.writeText(text).catch(() => {});
+  };
+
+  const handleExport = () => {
+    const text = visible.map(e => `[${new Date(e.ts).toISOString()}] [${LEVEL_LABEL[e.level]}] ${e.msg}`).join('\n');
+    const blob = new Blob([text], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `deplao-log-${Date.now()}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const FILTERS: ('all' | LogLevel)[] = ['all', 'error', 'warn', 'info', 'log', 'debug'];
+
+  return (
+    // Chiều cao cố định theo viewport để vùng list cuộn độc lập (parent Settings đã overflow-y-auto)
+    <div className="flex flex-col h-[calc(100vh-120px)]">
+      <div>
+        <h2 className="text-lg font-semibold text-white mb-1">Nhật ký hệ thống</h2>
+        <p className="text-xs text-gray-400 mb-3">Theo dõi mọi hoạt động (gửi tin, thêm liên hệ, lỗi…) theo thời gian thực.</p>
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 mb-2 flex-wrap flex-shrink-0">
+        <div className="flex gap-1">
+          {FILTERS.map(f => (
+            <button key={f} onClick={() => setFilter(f)}
+              className={`text-xs px-2.5 py-1 rounded-lg transition-colors ${
+                filter === f ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+              }`}>
+              {f === 'all' ? 'Tất cả' : LEVEL_LABEL[f]}
+            </button>
+          ))}
+        </div>
+        <input value={search} onChange={e => setSearch(e.target.value)}
+          placeholder="Tìm trong log..."
+          className="flex-1 min-w-[120px] bg-gray-700 border border-gray-600 rounded-lg px-3 py-1 text-xs text-white placeholder-gray-500 focus:outline-none focus:border-blue-500" />
+        <label className="flex items-center gap-1.5 text-xs text-gray-300 cursor-pointer">
+          <input type="checkbox" checked={autoScroll} onChange={e => setAutoScroll(e.target.checked)} className="accent-blue-500" />
+          Tự cuộn
+        </label>
+        <button onClick={handleCopy} className="text-xs px-2.5 py-1 rounded-lg bg-gray-700 text-gray-300 hover:bg-gray-600">Copy</button>
+        <button onClick={handleExport} className="text-xs px-2.5 py-1 rounded-lg bg-gray-700 text-gray-300 hover:bg-gray-600">Xuất file</button>
+        <button onClick={handleClear} className="text-xs px-2.5 py-1 rounded-lg bg-red-600/80 text-white hover:bg-red-600">Xóa</button>
+      </div>
+
+      <div className="text-[11px] text-gray-500 mb-1 flex-shrink-0">{visible.length} / {entries.length} dòng</div>
+
+      {/* Log list */}
+      <div className="flex-1 overflow-y-auto bg-gray-900 rounded-lg border border-gray-700 p-2 font-mono text-[11px] leading-relaxed">
+        {visible.length === 0 ? (
+          <p className="text-gray-500 text-center py-8">Chưa có log nào phù hợp</p>
+        ) : visible.map((e, i) => (
+          <div key={i} className="flex gap-2 py-0.5 hover:bg-gray-800/50 rounded px-1">
+            <span className="text-gray-500 flex-shrink-0">{fmt(e.ts)}</span>
+            <span className={`flex-shrink-0 w-16 ${LEVEL_STYLE[e.level]}`}>{LEVEL_LABEL[e.level]}</span>
+            <span className={`whitespace-pre-wrap break-all ${LEVEL_STYLE[e.level]}`}>{e.msg}</span>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/settings/RelayStatusPanel.tsx
+++ b/src/ui/components/settings/RelayStatusPanel.tsx
@@ -16,6 +16,24 @@ export default function RelayStatusPanel() {
     const [tunnelActive, setTunnelActive] = useState(false);
     const [tunnelUrl, setTunnelUrl] = useState<string | null>(null);
     const [tunnelLoading, setTunnelLoading] = useState(false);
+    // Tunnel provider config: cloudflare (URL random) | ngrok (static domain)
+    const [tunnelProvider, setTunnelProvider] = useState<'cloudflare' | 'ngrok'>('cloudflare');
+    const [ngrokToken, setNgrokToken] = useState('');
+    const [ngrokDomain, setNgrokDomain] = useState('');
+
+    useEffect(() => {
+        ipc.relay?.getTunnelConfig?.().then((res: any) => {
+            if (res?.success) {
+                setTunnelProvider(res.provider === 'ngrok' ? 'ngrok' : 'cloudflare');
+                setNgrokToken(res.authtoken || '');
+                setNgrokDomain(res.domain || '');
+            }
+        }).catch(() => {});
+    }, []);
+
+    const saveTunnelConfig = useCallback(async (cfg: { provider?: string; authtoken?: string; domain?: string }) => {
+        try { await ipc.relay?.setTunnelConfig?.(cfg); } catch { /* */ }
+    }, []);
 
     useEffect(() => {
         ipc.workspace?.getActive().then((res: any) => {
@@ -232,8 +250,47 @@ export default function RelayStatusPanel() {
                     <div className="space-y-0.5">
                         <p className="text-[10px] text-green-400">✓ Kết nối từ bất kỳ đâu qua internet</p>
                         <p className="text-[10px] text-green-400">✓ Không cần IP tĩnh hay port forward</p>
-                        <p className="text-[10px] text-gray-400">✗ URL thay đổi mỗi lần bật tunnel</p>
-                        <p className="text-[10px] text-gray-400">✗ Phụ thuộc server localtunnel.me</p>
+                        {tunnelProvider === 'ngrok'
+                            ? <p className="text-[10px] text-green-400">✓ URL cố định (ngrok static domain)</p>
+                            : <p className="text-[10px] text-gray-400">✗ URL thay đổi mỗi lần bật tunnel</p>}
+                    </div>
+
+                    {/* Provider selector — đổi được khi tunnel đang tắt */}
+                    <div className="space-y-1.5 pt-1 border-t border-gray-700/50">
+                        <div className="flex gap-1.5">
+                            {(['cloudflare', 'ngrok'] as const).map(p => (
+                                <button
+                                    key={p}
+                                    disabled={tunnelActive}
+                                    onClick={() => { setTunnelProvider(p); saveTunnelConfig({ provider: p }); }}
+                                    className={`flex-1 py-1 text-[10px] rounded-lg transition-colors disabled:opacity-50 ${
+                                        tunnelProvider === p ? 'bg-blue-600 text-white-important' : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                                    }`}
+                                >{p === 'cloudflare' ? 'Cloudflare (random)' : 'ngrok (cố định)'}</button>
+                            ))}
+                        </div>
+                        {tunnelProvider === 'ngrok' && (
+                            <div className="space-y-1">
+                                <input
+                                    value={ngrokToken}
+                                    onChange={e => setNgrokToken(e.target.value)}
+                                    onBlur={() => saveTunnelConfig({ authtoken: ngrokToken })}
+                                    disabled={tunnelActive}
+                                    type="password"
+                                    placeholder="ngrok authtoken"
+                                    className="w-full px-2 py-1 bg-gray-700 border border-gray-600 rounded-lg text-[10px] text-gray-200 disabled:opacity-50"
+                                />
+                                <input
+                                    value={ngrokDomain}
+                                    onChange={e => setNgrokDomain(e.target.value)}
+                                    onBlur={() => saveTunnelConfig({ domain: ngrokDomain })}
+                                    disabled={tunnelActive}
+                                    placeholder="static domain (vd: abc.ngrok-free.app)"
+                                    className="w-full px-2 py-1 bg-gray-700 border border-gray-600 rounded-lg text-[10px] text-gray-200 disabled:opacity-50"
+                                />
+                                <p className="text-[10px] text-gray-400">Lấy token + tạo domain free tại dashboard.ngrok.com</p>
+                            </div>
+                        )}
                     </div>
 
                     {/* Toggle button */}
@@ -266,14 +323,18 @@ export default function RelayStatusPanel() {
                                     className="text-gray-400 hover:text-blue-400 flex-shrink-0" title="Copy"
                                 ><ClipboardListIcon className="w-4 h-4" /></button>
                             </div>
-                            <p className="text-[10px] text-yellow-500/70"><AlertIcon className="w-4 h-4 inline" /> URL thay đổi mỗi lần bật lại</p>
+                            {tunnelProvider === 'ngrok'
+                                ? <p className="text-[10px] text-green-400/80">✓ URL cố định, không đổi khi bật lại</p>
+                                : <p className="text-[10px] text-yellow-500/70"><AlertIcon className="w-4 h-4 inline" /> URL thay đổi mỗi lần bật lại</p>}
                         </div>
                     )}
 
                     {/* Hint when idle */}
                     {relayRunning && !tunnelActive && (
                         <p className="text-[10px] text-gray-400 leading-relaxed pt-1 border-t border-gray-700/50">
-                            Dùng <span className="text-gray-400">localtunnel</span> - miễn phí, không cần cài đặt thêm. Phù hợp cho nhân viên làm việc từ xa hoặc work-from-home.
+                            {tunnelProvider === 'ngrok'
+                                ? 'Dùng ngrok static domain - URL cố định, nhân viên không cần cập nhật lại mỗi lần bật.'
+                                : 'Dùng Cloudflare tunnel - miễn phí, URL random mỗi lần. Chuyển sang ngrok nếu muốn URL cố định.'}
                         </p>
                     )}
                 </div>

--- a/src/ui/components/settings/Settings.tsx
+++ b/src/ui/components/settings/Settings.tsx
@@ -16,9 +16,10 @@ import ProxySettings from './ProxySettings';
 import LockScreenSettings from './LockScreenSettings';
 import AccountSettings from './AccountSettings';
 import TunnelSettings from './TunnelSettings';
+import LogViewer from './LogViewer';
 import { loadSeenTabs, markTabSeen, SETTINGS_WATCHLIST, hasUnseenChangelog, markChangelogSeen } from '@/utils/settingsSeenTabs';
 
-type SettingsTab = 'notifications' | 'accounts' | 'storage' | 'conversation' | 'employees' | 'workspace' | 'introduction' | 'changelog' | 'appearance' | 'proxy' | 'security' | 'webhooks';
+type SettingsTab = 'notifications' | 'accounts' | 'storage' | 'conversation' | 'employees' | 'workspace' | 'introduction' | 'changelog' | 'appearance' | 'proxy' | 'security' | 'webhooks' | 'logs';
 
 export default function Settings() {
   const [activeTab, setActiveTab] = useState<SettingsTab>('conversation');
@@ -168,6 +169,7 @@ export default function Settings() {
     { id: 'storage',       icon: <FolderIcon className="w-4 h-4" />, label: 'Lưu trữ' },
     { id: 'introduction',  icon: <BookIcon className="w-4 h-4" />, label: 'Giới thiệu' },
     { id: 'changelog',     icon: <ClipboardIcon className="w-4 h-4" />, label: 'Log phiên bản' },
+    { id: 'logs',          icon: <ClipboardListIcon className="w-4 h-4" />, label: 'Nhật ký' },
   ];
 
   // Filter nav items by permission - employee/simulation mode may hide certain tabs
@@ -517,6 +519,8 @@ export default function Settings() {
 
         {/* ── Security ── */}
         {activeTab === 'security' && <LockScreenSettings />}
+
+        {activeTab === 'logs' && <LogViewer />}
 
         {/* ── Employees ── */}
         {activeTab === 'proxy' && <ProxySettings />}

--- a/src/ui/lib/ipc.ts
+++ b/src/ui/lib/ipc.ts
@@ -352,6 +352,10 @@ declare global {
         download: () => void;
         install:  () => void;
       };
+      logs: {
+        getBuffer: () => Promise<{ ts: number; level: string; msg: string }[]>;
+        clear:     () => Promise<boolean>;
+      };
       workflow: {
         list: () => Promise<{ success: boolean; workflows: any[]; error?: string }>;
         get: (id: string) => Promise<{ success: boolean; workflow?: any; error?: string }>;
@@ -461,6 +465,8 @@ declare global {
         startTunnel: () => Promise<{ success: boolean; tunnelUrl?: string; error?: string }>;
         stopTunnel: () => Promise<{ success: boolean; error?: string }>;
         getTunnelStatus: () => Promise<{ success: boolean; active?: boolean; tunnelUrl?: string | null; error?: string }>;
+        getTunnelConfig: () => Promise<{ success: boolean; provider?: string; authtoken?: string; domain?: string; error?: string }>;
+        setTunnelConfig: (cfg: { provider?: string; authtoken?: string; domain?: string }) => Promise<{ success: boolean; error?: string }>;
       };
       // ─── Facebook ─────────────────────────────────────────────────────
       fb: {
@@ -689,6 +695,7 @@ export const ipc = {
   erp,
   lockScreen: window.electronAPI?.lockScreen,
   library: window.electronAPI?.library,
+  logs: window.electronAPI?.logs,
   on: window.electronAPI?.on,
   removeAllListeners: window.electronAPI?.removeAllListeners,
 };

--- a/src/ui/store/accountStore.ts
+++ b/src/ui/store/accountStore.ts
@@ -66,9 +66,22 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
           && a.channel === b?.channel;
       })
     ) {
+      // Danh sách không đổi, nhưng vẫn đảm bảo có active account nếu đang thiếu.
+      const cur = get().activeAccountId;
+      if ((!cur || !current.some(a => a.zalo_id === cur)) && accounts.length > 0) {
+        set({ activeAccountId: accounts[0].zalo_id });
+      }
       return;
     }
-    set({ accounts });
+    // Tự chọn active account đầu tiên nếu chưa có hoặc active cũ không còn tồn tại.
+    // Nhiều đường load account (workspace switch, employee snapshot, reconnect) không tự set active
+    // → thiếu bước này khiến CRM/nhãn/campaign nhận activeAccountId=null lúc khởi động.
+    const curActive = get().activeAccountId;
+    const stillValid = curActive && accounts.some(a => a.zalo_id === curActive);
+    set({
+      accounts,
+      ...(stillValid ? {} : { activeAccountId: accounts.length > 0 ? accounts[0].zalo_id : null }),
+    });
   },
 
   addAccount: (account) =>

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -4,14 +4,67 @@
  * Allows enable/disable logging via API or environment config
  * Cho phép bật/tắt logging thông qua API hoặc cấu hình môi trường
  */
+export type LogLevel = 'log' | 'error' | 'warn' | 'info' | 'debug';
+export interface LogEntry { ts: number; level: LogLevel; msg: string; }
+
+const MAX_BUFFER = 2000; // giữ 2000 dòng gần nhất trong RAM
+
+// Giữ tham chiếu console gốc để tránh đệ quy khi hook console toàn cục.
+const rawConsole = {
+    log: console.log.bind(console),
+    error: console.error.bind(console),
+    warn: console.warn.bind(console),
+    info: console.info.bind(console),
+    debug: console.debug.bind(console),
+};
+
 class Logger {
     private static instance: Logger;
     private isEnabled: boolean = false;
+    private buffer: LogEntry[] = [];
+    private listener: ((entry: LogEntry) => void) | null = null;
+    private consoleHooked = false;
 
     private constructor() {
-        // Default: Enable in development, disable in production
-        // Mặc định: Bật trong development, tắt trong production
+        // Buffer luôn ghi (kể cả production) để tab Nhật ký xem được;
+        // isEnabled chỉ điều khiển việc in ra console.
         this.isEnabled = process.env.NODE_ENV !== 'production';
+    }
+
+    /**
+     * Hook console.* toàn cục để mọi console thẳng (không qua Logger) cũng vào buffer.
+     * Gọi 1 lần ở main process. Dùng rawConsole để in ra → không đệ quy.
+     */
+    public installConsoleHook(): void {
+        if (this.consoleHooked) return;
+        this.consoleHooked = true;
+        const levels: LogLevel[] = ['log', 'error', 'warn', 'info', 'debug'];
+        for (const level of levels) {
+            (console as any)[level] = (...args: any[]) => {
+                this.record(level, args);
+                rawConsole[level](...args);
+            };
+        }
+    }
+
+    /** Đăng ký 1 listener (main process forward sang renderer). */
+    public onEntry(cb: (entry: LogEntry) => void): void { this.listener = cb; }
+
+    /** Lấy toàn bộ buffer hiện có (dùng khi mở tab lần đầu). */
+    public getBuffer(): LogEntry[] { return this.buffer; }
+
+    /** Xóa buffer. */
+    public clearBuffer(): void { this.buffer = []; }
+
+    private record(level: LogLevel, args: any[]): void {
+        const msg = args.map(a => {
+            if (typeof a === 'string') return a;
+            try { return JSON.stringify(a); } catch { return String(a); }
+        }).join(' ');
+        const entry: LogEntry = { ts: Date.now(), level, msg };
+        this.buffer.push(entry);
+        if (this.buffer.length > MAX_BUFFER) this.buffer.shift();
+        try { this.listener?.(entry); } catch { /* listener lỗi không được làm sập log */ }
     }
 
     public static getInstance(): Logger {
@@ -27,7 +80,7 @@ class Logger {
      */
     public enable(): void {
         this.isEnabled = true;
-        console.log(`[${new Date().toISOString()}] [Logger] ✅ Logging enabled`);
+        rawConsole.log(`[${new Date().toISOString()}] [Logger] ✅ Logging enabled`);
     }
 
     /**
@@ -35,7 +88,7 @@ class Logger {
      * Tắt logging
      */
     public disable(): void {
-        console.log(`[${new Date().toISOString()}] [Logger] 🔇 Logging disabled`);
+        rawConsole.log(`[${new Date().toISOString()}] [Logger] 🔇 Logging disabled`);
         this.isEnabled = false;
     }
 
@@ -66,8 +119,9 @@ class Logger {
      * Ghi log thông tin (chỉ khi được bật)
      */
     public log(...args: any[]): void {
+        this.record('log', args);
         if (this.isEnabled) {
-            console.log(...args);
+            rawConsole.log(...args);
         }
     }
 
@@ -76,7 +130,8 @@ class Logger {
      * Ghi log lỗi (luôn hiển thị, ngay cả khi tắt)
      */
     public error(...args: any[]): void {
-        console.error(...args);
+        this.record('error', args);
+        rawConsole.error(...args);
     }
 
     /**
@@ -84,8 +139,9 @@ class Logger {
      * Ghi log cảnh báo (chỉ khi được bật)
      */
     public warn(...args: any[]): void {
+        this.record('warn', args);
         if (this.isEnabled) {
-            console.warn(...args);
+            rawConsole.warn(...args);
         }
     }
 
@@ -94,8 +150,9 @@ class Logger {
      * Ghi log thông tin (chỉ khi được bật)
      */
     public info(...args: any[]): void {
+        this.record('info', args);
         if (this.isEnabled) {
-            console.info(...args);
+            rawConsole.info(...args);
         }
     }
 
@@ -104,8 +161,9 @@ class Logger {
      * Ghi log debug (chỉ khi được bật)
      */
     public debug(...args: any[]): void {
+        this.record('debug', args);
         if (this.isEnabled) {
-            console.debug(...args);
+            rawConsole.debug(...args);
         }
     }
 }


### PR DESCRIPTION
## Thay đổi

### Tính năng
- **Tag-all tùy chỉnh chữ**: khi bật tag toàn nhóm trong chiến dịch, thêm ô nhập chữ hiển thị (mặc định `@all`). Backend tự tính `len` khớp độ dài label, `uid: -1` (mention toàn nhóm Zalo) giữ nguyên.
  - `CRMQueueService.ts`: `len` tính động theo label
  - `CampaignCreateModal.tsx`: input chữ cạnh checkbox
- **message-markup parser**: thêm module parse định dạng text cho campaign (trước đây untracked).

### Fix deps
- Sync `package-lock.json` với binary theo nền tảng của `@ngrok/ngrok`.
- Thêm `react-is` làm direct dep để `recharts` resolve được trong Rollup build.

### CI
- `build-windows.yml`: publish release về repo hiện tại + `GITHUB_TOKEN` mặc định.

## Kiểm thử
- ✅ Compile electron + build renderer (Vite) pass local
- ✅ CI Build Windows pass → `.exe` 171MB build thành công